### PR TITLE
Remove final Keywords from Blocks

### DIFF
--- a/Block/Adminhtml/Config/Form/Field/AttributesAnonymizers.php
+++ b/Block/Adminhtml/Config/Form/Field/AttributesAnonymizers.php
@@ -13,7 +13,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
 use Magento\Framework\View\Element\Html\Select;
 
-final class AttributesAnonymizers extends AbstractFieldArray
+class AttributesAnonymizers extends AbstractFieldArray
 {
     private const ANONYMIZERS_SELECT = '\Opengento\Gdpr\Block\Adminhtml\Config\Form\Field\Select\Anonymizers';
 

--- a/Block/Adminhtml/Config/Form/Field/EraseComponentsProcessors.php
+++ b/Block/Adminhtml/Config/Form/Field/EraseComponentsProcessors.php
@@ -13,7 +13,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
 use Magento\Framework\View\Element\Html\Select;
 
-final class EraseComponentsProcessors extends AbstractFieldArray
+class EraseComponentsProcessors extends AbstractFieldArray
 {
     /**
      * @throws LocalizedException

--- a/Block/Adminhtml/Config/Form/Field/Select/OptionSourceSelect.php
+++ b/Block/Adminhtml/Config/Form/Field/Select/OptionSourceSelect.php
@@ -11,7 +11,7 @@ use Magento\Framework\Data\OptionSourceInterface;
 use Magento\Framework\View\Element\Context;
 use Magento\Framework\View\Element\Html\Select;
 
-final class OptionSourceSelect extends Select
+class OptionSourceSelect extends Select
 {
     /**
      * @var OptionSourceInterface

--- a/Block/Adminhtml/Order/Edit/EraseButton.php
+++ b/Block/Adminhtml/Order/Edit/EraseButton.php
@@ -14,7 +14,7 @@ use Magento\Framework\Phrase;
 use Magento\Sales\Block\Adminhtml\Order\View;
 use Opengento\Gdpr\Api\EraseEntityCheckerInterface;
 
-final class EraseButton extends AbstractBlock
+class EraseButton extends AbstractBlock
 {
     /**
      * @var EraseEntityCheckerInterface

--- a/Block/Adminhtml/Order/Edit/ExportButton.php
+++ b/Block/Adminhtml/Order/Edit/ExportButton.php
@@ -13,7 +13,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
 use Magento\Sales\Block\Adminhtml\Order\View;
 
-final class ExportButton extends AbstractBlock
+class ExportButton extends AbstractBlock
 {
     public function __construct(
         Context $context,

--- a/Block/Messages/PrivacyMessagePopup.php
+++ b/Block/Messages/PrivacyMessagePopup.php
@@ -15,7 +15,7 @@ use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Opengento\Gdpr\Model\Config;
 
-final class PrivacyMessagePopup extends Template
+class PrivacyMessagePopup extends Template
 {
     public const COOKIE_NAME = 'cookies-policy';
 


### PR DESCRIPTION
Compilation failed on Magento 2.3.3 and PHP 7.2.23 with the following errors:

```
Fatal error: Class Opengento\Gdpr\Block\Adminhtml\Config\Form\Field\AttributesAnonymizers\Interceptor may not inherit from final class (Opengento\Gdpr\Block\Adminhtml\Config\Form\Field\AttributesAnonymizers) in /usr/src/magento/generated/code/Opengento/Gdpr/Block/Adminhtml/Config/Form/Field/AttributesAnonymizers/Interceptor.php on line 7
Fatal error: Class Opengento\Gdpr\Block\Adminhtml\Config\Form\Field\Select\OptionSourceSelect\Interceptor may not inherit from final class (Opengento\Gdpr\Block\Adminhtml\Config\Form\Field\Select\OptionSourceSelect) in /usr/src/magento/generated/code/Opengento/Gdpr/Block/Adminhtml/Config/Form/Field/Select/OptionSourceSelect/Interceptor.php on line 7
Fatal error: Class Opengento\Gdpr\Block\Adminhtml\Config\Form\Field\EraseComponentsProcessors\Interceptor may not inherit from final class (Opengento\Gdpr\Block\Adminhtml\Config\Form\Field\EraseComponentsProcessors) in /usr/src/magento/generated/code/Opengento/Gdpr/Block/Adminhtml/Config/Form/Field/EraseComponentsProcessors/Interceptor.php on line 7
Fatal error: Class Opengento\Gdpr\Block\Adminhtml\Order\Edit\ExportButton\Interceptor may not inherit from final class (Opengento\Gdpr\Block\Adminhtml\Order\Edit\ExportButton) in /usr/src/magento/generated/code/Opengento/Gdpr/Block/Adminhtml/Order/Edit/ExportButton/Interceptor.php on line 7
Fatal error: Class Opengento\Gdpr\Block\Adminhtml\Order\Edit\EraseButton\Interceptor may not inherit from final class (Opengento\Gdpr\Block\Adminhtml\Order\Edit\EraseButton) in /usr/src/magento/generated/code/Opengento/Gdpr/Block/Adminhtml/Order/Edit/EraseButton/Interceptor.php on line 7
Fatal error: Class Opengento\Gdpr\Block\Messages\PrivacyMessagePopup\Interceptor may not inherit from final class (Opengento\Gdpr\Block\Messages\PrivacyMessagePopup) in /usr/src/magento/generated/code/Opengento/Gdpr/Block/Messages/PrivacyMessagePopup/Interceptor.php on line 7
```

This pull request fixes those errors by removing the offending `final` keyword from the Block classes.