### PR TITLE
Fix syntax when modifying dates in EraseSalesInformation

### DIFF
--- a/Model/Erase/EraseSalesInformation.php
+++ b/Model/Erase/EraseSalesInformation.php
@@ -51,7 +51,7 @@ final class EraseSalesInformation implements EraseSalesInformationInterface
     public function scheduleEraseEntity(int $entityId, string $entityType, \DateTime $lastActive): EraseEntityInterface
     {
         $dateTime = DateTimeImmutable::createFromMutable($lastActive);
-        $scheduleAt = $dateTime->modify('+' . $this->config->getErasureSalesMaxAge() . + 'days');
+        $scheduleAt = $dateTime->modify('+' . $this->config->getErasureSalesMaxAge() . ' days');
 
         /** @var EraseEntityInterface $eraseEntity */
         $eraseEntity = $this->eraseEntityFactory->create();


### PR DESCRIPTION
I was getting the following error when running the CLI command to erase customer data:
```
Impossible to process the erasure: Warning: A non-numeric value encountered in /src/www/vendor/opengento/module-gdpr/Model/Erase/EraseSalesInformation.php on line 54
```

After looking a bit into it, it seems to me the issue is the extra '+' I removed in this pull request. I hope I'm not missing something, but I'm pretty sure it's wrong there. After removing it, everything seems to work again.