### PR TITLE
Fix di compilation

### DIFF
--- a/Controller/AbstractGuest.php
+++ b/Controller/AbstractGuest.php
@@ -10,6 +10,7 @@ namespace Opengento\Gdpr\Controller;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Registry;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Controller\AbstractController\OrderLoaderInterface;
@@ -30,13 +31,14 @@ abstract class AbstractGuest extends AbstractAction
     public function __construct(
         RequestInterface $request,
         ResultFactory $resultFactory,
+        ManagerInterface $messageManager,
         Config $config,
         OrderLoaderInterface $orderLoader,
         Registry $registry
     ) {
         $this->orderLoader = $orderLoader;
         $this->registry = $registry;
-        parent::__construct($request, $resultFactory, $config);
+        parent::__construct($request, $resultFactory, $messageManager, $config);
     }
 
     public function execute()

--- a/Controller/Guest/Download.php
+++ b/Controller/Guest/Download.php
@@ -16,6 +16,7 @@ use Magento\Framework\Controller\Result\Redirect;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Phrase;
 use Magento\Framework\Registry;
 use Magento\Sales\Api\Data\OrderInterface;
@@ -39,6 +40,7 @@ class Download extends AbstractGuest implements HttpGetActionInterface
     public function __construct(
         RequestInterface $request,
         ResultFactory $resultFactory,
+        ManagerInterface $messageManager,
         Config $config,
         OrderLoaderInterface $orderLoader,
         Registry $registry,
@@ -47,7 +49,7 @@ class Download extends AbstractGuest implements HttpGetActionInterface
     ) {
         $this->fileFactory = $fileFactory;
         $this->exportRepository = $exportRepository;
-        parent::__construct($request, $resultFactory, $config, $orderLoader, $registry);
+        parent::__construct($request, $resultFactory, $messageManager, $config, $orderLoader, $registry);
     }
 
     protected function isAllowed(): bool

--- a/Controller/Guest/Erase.php
+++ b/Controller/Guest/Erase.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\Result\Redirect;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Phrase;
 use Magento\Framework\Registry;
 use Magento\Sales\Controller\AbstractController\OrderLoaderInterface;
@@ -37,6 +38,7 @@ class Erase extends AbstractGuest implements HttpPostActionInterface
     public function __construct(
         RequestInterface $request,
         ResultFactory $resultFactory,
+        ManagerInterface $messageManager,
         Config $config,
         OrderLoaderInterface $orderLoader,
         Registry $registry,
@@ -45,7 +47,7 @@ class Erase extends AbstractGuest implements HttpPostActionInterface
     ) {
         $this->action = $action;
         $this->actionContextBuilder = $actionContextBuilder;
-        parent::__construct($request, $resultFactory, $config, $orderLoader, $registry);
+        parent::__construct($request, $resultFactory, $messageManager, $config, $orderLoader, $registry);
     }
 
     protected function isAllowed(): bool

--- a/Controller/Guest/Export.php
+++ b/Controller/Guest/Export.php
@@ -14,6 +14,7 @@ use Magento\Framework\Controller\Result\Redirect;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Phrase;
 use Magento\Framework\Registry;
 use Magento\Sales\Controller\AbstractController\OrderLoaderInterface;
@@ -38,6 +39,7 @@ class Export extends AbstractGuest implements HttpGetActionInterface
     public function __construct(
         RequestInterface $request,
         ResultFactory $resultFactory,
+        ManagerInterface $messageManager,
         Config $config,
         OrderLoaderInterface $orderLoader,
         Registry $registry,
@@ -46,7 +48,7 @@ class Export extends AbstractGuest implements HttpGetActionInterface
     ) {
         $this->action = $action;
         $this->actionContextBuilder = $actionContextBuilder;
-        parent::__construct($request, $resultFactory, $config, $orderLoader, $registry);
+        parent::__construct($request, $resultFactory, $messageManager, $config, $orderLoader, $registry);
     }
 
     protected function isAllowed(): bool

--- a/Controller/Guest/UndoErase.php
+++ b/Controller/Guest/UndoErase.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\Result\Redirect;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Phrase;
 use Magento\Framework\Registry;
 use Magento\Sales\Controller\AbstractController\OrderLoaderInterface;
@@ -37,6 +38,7 @@ class UndoErase extends AbstractGuest implements HttpPostActionInterface
     public function __construct(
         RequestInterface $request,
         ResultFactory $resultFactory,
+        ManagerInterface $messageManager,
         Config $config,
         OrderLoaderInterface $orderLoader,
         Registry $registry,
@@ -45,7 +47,7 @@ class UndoErase extends AbstractGuest implements HttpPostActionInterface
     ) {
         $this->action = $action;
         $this->actionContextBuilder = $actionContextBuilder;
-        parent::__construct($request, $resultFactory, $config, $orderLoader, $registry);
+        parent::__construct($request, $resultFactory, $messageManager, $config, $orderLoader, $registry);
     }
 
     protected function isAllowed(): bool


### PR DESCRIPTION
Currently on Magento 2.4.1 when running the di compilation:

`
Compilation was started.
Interception cache generation... 6/9 [==================>---------]  66% 2 mins 450.0 MiB
Errors during compilation:
	Opengento\Gdpr\Controller\AbstractGuest
		Incompatible argument type: Required type: \Magento\Framework\Message\ManagerInterface. Actual type: \Opengento\Gdpr\Model\Config; File:
/var/www/html/vendor/opengento/module-gdpr/Controller/AbstractGuest.php

Total Errors Count: 1
`