### PR TITLE
Update customer_account.xml

### DIFF
--- a/view/frontend/layout/customer_account.xml
+++ b/view/frontend/layout/customer_account.xml
@@ -8,10 +8,10 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="customer_account_navigation">
-            <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-account-privacy-link">
+            <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-account-privacy-link" ifconfig="gdpr/general/enabled">
                 <arguments>
                     <argument name="path" xsi:type="string">customer/privacy/settings</argument>
-                    <argument name="label" xsi:type="string" translate="true"><![CDATA[Privacy Settings]]></argument>
+                    <argument name="label" xsi:type="string" translate="true">Privacy Settings</argument>
                     <argument name="sortOrder" xsi:type="number">175</argument>
                 </arguments>
             </block>

--- a/view/frontend/layout/customer_account.xml
+++ b/view/frontend/layout/customer_account.xml
@@ -8,10 +8,11 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="customer_account_navigation">
-            <block class="Magento\Framework\View\Element\Html\Link\Current" name="customer-account-navigation-privacy-link" after="customer-account-navigation-wish-list-link" ifconfig="gdpr/general/enabled">
+            <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-account-privacy-link">
                 <arguments>
                     <argument name="path" xsi:type="string">customer/privacy/settings</argument>
-                    <argument name="label" xsi:type="string" translate="true">Privacy Settings</argument>
+                    <argument name="label" xsi:type="string" translate="true"><![CDATA[Privacy Settings]]></argument>
+                    <argument name="sortOrder" xsi:type="number">175</argument>
                 </arguments>
             </block>
         </referenceBlock>


### PR DESCRIPTION
Using block Magento\Customer\Block\Account\SortLinkInterface instead of Magento\Framework\View\Element\Html\Link\Current
to be able to sort link by sortOrder function