### PR TITLE
Fix error 'The "formElement" configuration parameter is required for the "name" field.' (Magento 2.4.2)

### DIFF
--- a/view/adminhtml/ui_component/gdpr_action_form.xml
+++ b/view/adminhtml/ui_component/gdpr_action_form.xml
@@ -84,7 +84,7 @@
                         <item name="showFallbackReset" xsi:type="boolean">false</item>
                     </item>
                 </argument>
-                <field name="name" sortOrder="10">
+                <field name="name" formElement="input" sortOrder="10">
                     <settings>
                         <dataType>text</dataType>
                         <label translate="true">Name</label>
@@ -95,7 +95,7 @@
                         </validation>
                     </settings>
                 </field>
-                <field name="value" sortOrder="20">
+                <field name="value" formElement="input" sortOrder="20">
                     <settings>
                         <dataType>text</dataType>
                         <label translate="true">Value</label>

--- a/view/adminhtml/ui_component/gdpr_action_form.xml
+++ b/view/adminhtml/ui_component/gdpr_action_form.xml
@@ -84,7 +84,7 @@
                         <item name="showFallbackReset" xsi:type="boolean">false</item>
                     </item>
                 </argument>
-                <field name="name" formElement="input" sortOrder="10">
+                <input name="name" sortOrder="10">
                     <settings>
                         <dataType>text</dataType>
                         <label translate="true">Name</label>
@@ -94,8 +94,8 @@
                             <rule name="required-entry" xsi:type="boolean">true</rule>
                         </validation>
                     </settings>
-                </field>
-                <field name="value" formElement="input" sortOrder="20">
+                </input>
+                <input name="value" sortOrder="20">
                     <settings>
                         <dataType>text</dataType>
                         <label translate="true">Value</label>
@@ -105,7 +105,7 @@
                             <rule name="required-entry" xsi:type="boolean">true</rule>
                         </validation>
                     </settings>
-                </field>
+                </input>
                 <actionDelete/>
             </container>
         </dynamicRows>


### PR DESCRIPTION
Fix error 'The "formElement" configuration parameter is required for the "name" field.' (Magento 2.4.2)