### PR TITLE
Prevent errors in getRandomNumber call on PHP 8.1

### DIFF
--- a/Service/Anonymize/Anonymizer/Number.php
+++ b/Service/Anonymize/Anonymizer/Number.php
@@ -29,8 +29,8 @@ final class Number implements AnonymizerInterface
         ?int $min = null,
         ?int $max = null
     ) {
-        $this->min = $min !== null && $min < PHP_INT_MIN ? PHP_INT_MIN : $min;
-        $this->max = $max !== null && $max < PHP_INT_MAX ? PHP_INT_MAX : $max;
+        $this->min = $min < PHP_INT_MIN ? PHP_INT_MIN : $min;
+        $this->max = $max !== null && $max > PHP_INT_MAX ? PHP_INT_MAX : $max;
     }
 
     /**


### PR DESCRIPTION
It is now mandatory to pass an integer to the function; otherwise an error is thrown. This is due to changes in PHP 8 that removed using null as parameter in many php functions.

Currently if min is defined as null it will be passed as null, throwing an error.

Max is allowed to be null, however, since the Magento function will assign it a value if it's null.

I also assumed the original comparison of less than for max value was incorrect and changed it.